### PR TITLE
Fixed error when secret length is not divisible by 8

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,8 @@ class KeywordQueryEventListener(EventListener):
 
             secrets = provider.split("=")
             name = secrets[0]
-            token = str(otp.get_totp(secrets[1])).zfill(6)
+            secret = secrets[1] + '=' * (8 - len(secrets[1]) % 8)
+            token = str(otp.get_totp(secret)).zfill(6)
 
             items.append(ExtensionResultItem(icon='images/icon.png',
                                              name='%s' % token,


### PR DESCRIPTION
When the seed secret length is not divisible by 8, `base64.b32decode()` (called by `otp.get_totp()`) will throw an error `binascii.Error: Incorrect padding`. This commit fixes it by appending enough padding (`=`) to make the length divisible by 8.

Moreover, to allow the installation by Ulauncher, the branch should be called `master`, not `main`. There is a bug report regarding [this issue](https://github.com/Ulauncher/Ulauncher/issues/1132#issuecomment-1434688996) on Ulauncher's GitHub.