### PR TITLE
Fix error when the length of the secret isn't a multiple of 8

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,8 @@ class KeywordQueryEventListener(EventListener):
 
             secrets = provider.split("=")
             name = secrets[0]
-            token = str(otp.get_totp(secrets[1])).zfill(6)
+            secret = secrets[1] + '=' * (8 - len(secrets[1]) % 8)
+            token = str(otp.get_totp(secret)).zfill(6)
 
             items.append(ExtensionResultItem(icon='images/icon.png',
                                              name='%s' % token,

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ class KeywordQueryEventListener(EventListener):
 
             secrets = provider.split("=")
             name = secrets[0]
-            secret = secrets[1] + '=' * (8 - len(secrets[1]) % 8)
+            secret = secrets[1] + '=' * ((8 - len(secrets[1])) % 8)
             token = str(otp.get_totp(secret)).zfill(6)
 
             items.append(ExtensionResultItem(icon='images/icon.png',


### PR DESCRIPTION
When the secret is not a multiple of 8, the library `base64` throws the following:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/adriancarreno/.local/lib/python3.8/site-packages/onetimepass/__init__.py", line 164, in get_totp
    return get_hotp(
  File "/home/adriancarreno/.local/lib/python3.8/site-packages/onetimepass/__init__.py", line 113, in get_hotp
    key = base64.b32decode(secret, casefold=casefold)
  File "/usr/lib/python3.8/base64.py", line 205, in b32decode
    raise binascii.Error('Incorrect padding')
binascii.Error: Incorrect padding
```

[RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-6) defines the encoding of `base32` as 40-bit groups of input bits as output strings of 8 encoded characters. This means the secret length should be a multiple of 8. Padding is possible by appending the `=` character to the string until the length is 8-divisible. `base64.b32decode` will not automatically pad the string, and will simply raise a `binascii.Error: Incorrect padding` error. 

This PR will add the necessary number of `=` characters to achieve an appropriate length, compliant with RFC 4648.